### PR TITLE
Expose the mqttc loop functions, and option to avoid the auto start

### DIFF
--- a/sondehub/__main__.py
+++ b/sondehub/__main__.py
@@ -47,9 +47,8 @@ def main():
     ):  # we need to drop the default value if the user specifies specific sondes
         args.sondes = args.sondes[1:]
     sondes = [item for sublist in args.sondes for item in sublist]
-    test = sondehub.Stream(on_message=on_message, sondes=sondes)
-    while 1:
-        time.sleep(0.01) # don't overwork the CPU waiting for events
+    test = sondehub.Stream(on_message=on_message, sondes=sondes, auto_start_loop=False)
+    test.loop_forever()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This also makes a cleaner `main()` by using `loop_forever()`

Default for auto_start_loop is backwards compatible and structured to
allow for changing the default later and/or raising a warning if not
set.